### PR TITLE
Correctly respect user installed CAs

### DIFF
--- a/app.json
+++ b/app.json
@@ -40,7 +40,8 @@
           },
           "ios": {}
         }
-      ]
+      ],
+      ["./plugins/withTrustLocalCerts.js"]
     ],
     "experiments": {
       "typedRoutes": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "expo-auth-session": "^6.2.1",
         "expo-blur": "~14.1.5",
         "expo-build-properties": "~0.14.8",
+        "expo-config-plugins": "0.1.2",
         "expo-constants": "~17.1.6",
         "expo-crypto": "^14.1.5",
         "expo-document-picker": "^13.1.6",
@@ -8601,6 +8602,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/expo-config-plugins": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/expo-config-plugins/-/expo-config-plugins-0.1.2.tgz",
+      "integrity": "sha512-C3+vsMVZwmwUpXaeXp4++u7l9ZAfsmeTxscSwfmOOgQ3FvLoMV6BrFPdFHPKivpIN6z/+IXb9y/wrf8+4AtDXQ==",
+      "license": "MIT"
     },
     "node_modules/expo-constants": {
       "version": "17.1.7",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "expo-auth-session": "^6.2.1",
     "expo-blur": "~14.1.5",
     "expo-build-properties": "~0.14.8",
+    "expo-config-plugins": "0.1.2",
     "expo-constants": "~17.1.6",
     "expo-crypto": "^14.1.5",
     "expo-document-picker": "^13.1.6",

--- a/plugins/network_security_config.xml
+++ b/plugins/network_security_config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+    <!-- Allow cleartext network traffic -->
+    <base-config
+        cleartextTrafficPermitted="true"
+        tools:ignore="InsecureBaseConfiguration">
+        <trust-anchors>
+            <!-- Trust pre-installed CAs -->
+            <certificates src="system" />
+            <!-- Additionally trust user added CAs -->
+            <certificates
+                src="user"
+                tools:ignore="AcceptsUserCertificates" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/plugins/withTrustLocalCerts.js
+++ b/plugins/withTrustLocalCerts.js
@@ -1,0 +1,44 @@
+const { AndroidConfig, withAndroidManifest } = require("@expo/config-plugins");
+const { Paths } = require("@expo/config-plugins/build/android");
+const path = require("node:path");
+const fs = require("node:fs");
+const fsPromises = fs.promises;
+
+const { getMainApplicationOrThrow } = AndroidConfig.Manifest;
+
+const withTrustLocalCerts = (config) => {
+  return withAndroidManifest(config, async (config) => {
+    config.modResults = await setCustomConfigAsync(config, config.modResults);
+    return config;
+  });
+};
+
+async function setCustomConfigAsync(config, androidManifest) {
+  const src_file_path = path.join(__dirname, "network_security_config.xml");
+  const res_file_path = path.join(
+    await Paths.getResourceFolderAsync(config.modRequest.projectRoot),
+    "xml",
+    "network_security_config.xml",
+  );
+
+  const res_dir = path.resolve(res_file_path, "..");
+
+  if (!fs.existsSync(res_dir)) {
+    await fsPromises.mkdir(res_dir);
+  }
+
+  try {
+    await fsPromises.copyFile(src_file_path, res_file_path);
+  } catch (e) {
+    throw new Error(
+      `Failed to copy network security config file from ${src_file_path} to ${res_file_path}: ${e.message}`,
+    );
+  }
+  const mainApplication = getMainApplicationOrThrow(androidManifest);
+  mainApplication.$["android:networkSecurityConfig"] =
+    "@xml/network_security_config";
+
+  return androidManifest;
+}
+
+module.exports = withTrustLocalCerts;


### PR DESCRIPTION
This change makes the app correctly check for the user certificate store in android and validates HTTPS request correctly in case of self signed certificate use. See [this PRs](https://github.com/streamyfin/streamyfin/pull/451) for a more detailed explanation of the changes made here.